### PR TITLE
Add remote_write feature configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ landscape:
       resourceGroup:                          # Azure resource group you would like to use for your backup
       region: (( iaas.region ))               # region of blob storage (default: same as above)
       credentials: (( iaas.credentials ))     # credentials for the blob storage's IaaS provider (default: same as above)
+    resources:                                # optional: override resource requests and limits defaults
+      requests:
+        cpu: 400m
+        memory: 2000Mi
+      limits:
+        cpu: 1
+        memory: 2560Mi
 
   <a href="#landscapedns">dns</a>:                                    # optional for gcp/aws/azure/openstack, default values based on `landscape.iaas`
     type: &lt;google-clouddns|aws-route53|azure-dns|openstack-designate|cloudflare-dns|infoblox-dns&gt;   # dns provider

--- a/acre.yaml
+++ b/acre.yaml
@@ -248,6 +248,7 @@ landscape:
     username: admin
     password: (( ~~ ))
     hash: (( ~~ ))
+    customScrapeConfigPath: (( ~~ ))
   cert-manager:
     <<: (( merge ))
     server: (( merge none // valid( stub() ) ? ( type( stub() ) == "map" ? stub() :{ "url" = stub() } ) :{"url" = "self-signed"} ))

--- a/acre.yaml
+++ b/acre.yaml
@@ -249,6 +249,8 @@ landscape:
     password: (( ~~ ))
     hash: (( ~~ ))
     customScrapeConfigPath: (( ~~ ))
+    remoteWrite: (( ~~ ))
+    externalLabels: (( ~~ ))
   cert-manager:
     <<: (( merge ))
     server: (( merge none // valid( stub() ) ? ( type( stub() ) == "map" ? stub() :{ "url" = stub() } ) :{"url" = "self-signed"} ))

--- a/acre.yaml
+++ b/acre.yaml
@@ -704,6 +704,9 @@ validation:
             - - optionalfield
               - privateKey
               - privatekey
+    - - optionalfield
+      - resources
+      - (( validation.resources_validator ))
   dashboard_no_seed_strategy_validator: (( |db|-> [! defined( db.frontendConfig.seedCandidateDeterminationStrategy ), "valid", "the 'frontendConfig.seedCandidateDeterminationStrategy' value for the dashboard is derived from the Gardener config and cannot be set here - set 'landscape.gardener.seedCandidateDeterminationStrategy' instead"] ))
   dashboard_terminals_validator: (( |db,cm|-> [! (( db.terminals.active || false ) -and ( cm.server.url == "self-signed" -or cm.server.url == "staging" )), "valid", "the 'dashboard terminals' feature requires trusted certificates, please configure the cert-manager accordingly"] ))
   networks:
@@ -760,6 +763,17 @@ validation:
     - ["optionalfield", "allowProjectCreationForAll", ["type", "bool"]]
     - ["optionalfield", "useIdentityDomain", ["type", "bool"]]
 
+  resources_validator:                      # resource nodes are
+    - map                                   # maps that contain
+    - ["valueset", ["limits", "requests"]]  # the keys 'limits' or 'requests' only,
+    - - map                                 # which in turn contain a map
+      - - or                                # with the following keys:
+        - ["valueset", ["cpu", "memory"]]   # 'cpu' or 'memory' exactly, or
+        - ["match", "^hugepages-"]          # a key starting with 'hugepages-'.
+      - - or                                # these maps either contain
+        - ["type", "int"]                   # integers or
+        - ["type", "string"]                # strings
+
 
   ### VALIDATIONS ###
   # structure resembles structure of landscape where possible
@@ -779,6 +793,7 @@ validation:
     shooted_seed: (( map[validation.flatten( select[select[landscape.iaas|elem|-> elem.mode == "seed" -or elem.mode == "soil"]|elem|-> valid( elem.seeds )].[*].seeds ) |entry|-> validate( entry, validation.instantiate_validator(entry, iaas_entry_validators.basic), validation.instantiate_validator(entry, iaas_entry_validators.shooted_seed) )] ))
   ##### landscape.etcd
   etcd:
+    resources: (( defined( landscape.etcd.resources ) ? validate( landscape.etcd.resources, validation.resources_validator ) :~~ ))
     backup_active: (( validate( landscape.etcd.backup.active, ["type", "bool"] ) ))
     backup: (( landscape.etcd.backup.active == true ? validate( landscape.etcd.backup, [ "and", validation.instantiate_validator( landscape.etcd.backup, validation.types.backup_config ), validation.types.etcd_backup[landscape.etcd.backup.type].config ] ) :~~ ))
   ##### landscape.dns
@@ -789,6 +804,11 @@ validation:
     credentials: (( validate( landscape.dns, ["mapfield", "credentials", types.dns[landscape.dns.type].credentials] ) ))
   ##### landscape.gardener
   gardener:
+    resources:
+      apiserver: (( defined( landscape.gardener.resources.apiserver ) ? validate( landscape.gardener.resources.apiserver, validation.resources_validator ) :~~ ))
+      admission: (( defined( landscape.gardener.resources.admission ) ? validate( landscape.gardener.resources.admission, validation.resources_validator ) :~~ ))
+      controller: (( defined( landscape.gardener.resources.controller ) ? validate( landscape.gardener.resources.controller, validation.resources_validator ) :~~ ))
+      scheduler: (( defined( landscape.gardener.resources.scheduler ) ? validate( landscape.gardener.resources.scheduler, validation.resources_validator ) :~~ ))
     seedCandidateDeterminationStrategy: (( defined( landscape.gardener.seedCandidateDeterminationStrategy ) ? validate( landscape.gardener, ["optionalfield", "seedCandidateDeterminationStrategy", ["valueset", ["SameRegion", "MinimalDistance"]]] ) :~~ ))
     network-policies: (( defined( landscape.gardener.network-policies ) ? validate( landscape.gardener.network-policies, ["optionalfield", "active", ["type", "bool"]] ) :~~ ))
     extensions: (( defined( landscape.gardener.extensions ) ? validate( keys( landscape.gardener.extensions ), ["list", ["valueset", keys( landscape.versions.gardener.extensions )]] ) :~~ ))

--- a/components/dashboard/deployment.yaml
+++ b/components/dashboard/deployment.yaml
@@ -79,6 +79,8 @@ dashboard:
         <<: (( .landscape.dashboard.frontendConfig.features || ~ ))
         terminalEnabled: (( ( .landscape.dashboard.terminals.active || false ) ))
     terminal: (( ( .landscape.dashboard.terminals.active || false ) ? *.terminal_config :~~ ))
+    resources:
+      <<: (( .landscape.dashboard.resources || ~~ ))
 
 terminal_config:
   <<: (( &temporary &template ))

--- a/components/etcd/cluster/chart/templates/statefulset-etcd.yaml
+++ b/components/etcd/cluster/chart/templates/statefulset-etcd.yaml
@@ -81,11 +81,11 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 200m
-            memory: 500Mi
+            cpu: {{ .Values.resources.requests.cpu | default "400m" }}
+            memory: {{ .Values.resources.requests.memory | default "2000Mi" }}
           limits:
-            cpu: 750m
-            memory: 2560Mi
+            cpu: {{ .Values.resources.limits.cpu | default "1000m" }}
+            memory: {{ .Values.resources.limits.memory | default "2560Mi" }}
         volumeMounts:
         - name: {{ .Values.name }}
           mountPath: /var/etcd/data

--- a/components/etcd/cluster/chart/values.yaml
+++ b/components/etcd/cluster/chart/values.yaml
@@ -38,6 +38,14 @@ tls:
     crt: client-certificate
     key: client-key
 
+resources:
+  requests:
+    cpu: 400m
+    memory: 2000Mi
+  limits:
+    cpu: 1000m
+    memory: 2560Mi
+
 # Aws S3 storage configuration
 # Note: No volumeMounts variable needed
 # storageProvider: "S3"

--- a/components/etcd/cluster/deployment.yaml
+++ b/components/etcd/cluster/deployment.yaml
@@ -108,6 +108,8 @@ etcd:
           crt: (( state.client.value.cert ))
           key: (( state.client.value.key ))
 
+      resources:
+        <<: (( landscape.etcd.resources || ~~ ))
   events:
     kubeconfig: (( landscape.clusters.[0].kubeconfig ))
     files:

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -59,7 +59,18 @@ secretManifests:
   type: Opaque
   data:
     <<: (( sum[configValues.dns.credentials|{}|ss,sk,sv|-> ss { sk = base64(sv) }] ))
-
+- <<: (( defined(configValues.monitoring.remoteWrite) ? ~ :~~ ))
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: "monitoring-seed-remote-write-credentials"
+    namespace: "garden"
+    labels:
+      gardener.cloud/role: global-shoot-remote-write-monitoring
+  type: Opaque
+  data:
+    username: (( base64(configValues.monitoring.remoteWrite.username) ))
+    password: (( base64(configValues.monitoring.remoteWrite.password) ))
 seedSpec:
   <<: (( &temporary ))
   provider:
@@ -226,10 +237,21 @@ gardenletSpec:
           metadata:
             name: (( configValues.name ))
           spec: (( seedSpec ))
+        monitoring: (( defined(configValues.monitoring.remoteWrite) ? monitoringTemplate :~~ ))
     # Deployment related configuration
     deployment:
       virtualGarden:
         enabled: true
+
+monitoringTemplate:
+  <<: (( &temporary ))
+  shoot:
+    remoteWrite:
+      url: (( configValues.monitoring.remoteWrite.url || ~~ ))
+      keep: (( configValues.monitoring.remoteWrite.keep || ~~ ))
+      queueConfig: (( configValues.monitoring.remoteWrite.queueConfig || ~~ ))
+    externalLabels:
+      <<: (( configValues.monitoring.externalLabels || {} ))
 
 pluginSpecs:
   managedIstioActive: (( configValues.config.featureGates.ManagedIstio || false ))

--- a/components/gardencontent/seeds/manifests/seed_manifests.yaml
+++ b/components/gardencontent/seeds/manifests/seed_manifests.yaml
@@ -214,6 +214,8 @@ gardenletSpec:
           retryPeriod: 2s
           resourceLock: configmaps
         logLevel: info
+        logging:
+          <<: (( configValues.config.logging || ~~ ))
         kubernetesLogLevel: 0
         featureGates: 
           <<: (( configValues.config.featureGates || {} ))

--- a/components/gardencontent/seeds/soils/deployment.yaml
+++ b/components/gardencontent/seeds/soils/deployment.yaml
@@ -76,5 +76,6 @@ providerconfig:
     shootDefaultNetworks: (( v.shootDefaultNetworks || ~~ ))
     settings: (( v.seedSettings || ~~ ))
   secretname: (( name "-" v.mode ))
+  monitoring: (( landscape.monitoring ))
 
 renderedPluginSpecs: (( sum[.iaasSeedsSoils|[]|s,id,v|-> s [ ( "configValues" = *providerconfig ) read( __ctx.DIR "/../manifests/seed_manifests.yaml", "yaml" ).pluginSpecs ]] ))

--- a/components/gardener/virtual/deployment.yaml
+++ b/components/gardener/virtual/deployment.yaml
@@ -117,11 +117,11 @@ default_resources:
       memory: 100Mi
   scheduler:
     limits:
-      cpu: (( ~~ ))
-      memory: (( ~~ ))
+      cpu: 300m
+      memory: 256Mi
     requests:
-      cpu: (( ~~ ))
-      memory: (( ~~ ))
+      cpu: 50m
+      memory: 50Mi
 
 gardener:
   kubeconfig: (( landscape.clusters.[0].kubeconfig ))

--- a/components/monitoring/prometheus/deployment.yaml
+++ b/components/monitoring/prometheus/deployment.yaml
@@ -19,6 +19,7 @@ kubectlconfig:
 settings:
   monitoring_credentials: (( .state.monitoring_credentials.value ))
   prometheus_domain: (( "garden-prometheus." .imports.ingress-controller.export.ingress_domain ))
+  monitoring: (( landscape.monitoring ))
 
 monitoring_password:
   <<: (( &temporary ))

--- a/components/monitoring/prometheus/deployment.yaml
+++ b/components/monitoring/prometheus/deployment.yaml
@@ -20,7 +20,6 @@ settings:
   monitoring_credentials: (( .state.monitoring_credentials.value ))
   prometheus_domain: (( "garden-prometheus." .imports.ingress-controller.export.ingress_domain ))
   monitoring: (( landscape.monitoring ))
-
 monitoring_password:
   <<: (( &temporary ))
   input:

--- a/components/monitoring/prometheus/manifests/02-prometheus-config.yaml
+++ b/components/monitoring/prometheus/manifests/02-prometheus-config.yaml
@@ -8,38 +8,45 @@ metadata:
     role: prometheus
     context: garden
 data:
-  config.yaml: (( asyaml( config_data ) ))
+  config.yaml: (( asyaml( templates.config_data ) ))
 
+templates:
+  <<: (( &temporary ))
 
-config_data:
-  <<: (( &temporary ))    
-  global:
-    evaluation_interval: 30s
-    scrape_interval: 30s
+  custom_path: (( values.settings.monitoring.customScrapeConfigPath || ~~ )) # to improve readability
+  parse_scrape_configs: (( lambda |folder|-> sum[list_files( folder )|[]|scrape,file|-> scrape read( folder "/" file )] ))
+  default_scrape_configs: (( templates.parse_scrape_configs( __ctx.DIR "/manifests/scrape-configs" ) ))
+  custom_scrape_configs: (( defined(templates.custom_path) ? templates.parse_scrape_configs( templates.custom_path ) :[] ))
 
-  rule_files:
-  - /etc/prometheus/rules/*.yaml
+  config_data:
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 30s
 
-  alerting:
-    alertmanagers:
-    - kubernetes_sd_configs:
-      - role: endpoints
-        namespaces:
-          names:
-          - garden
-      scheme: http
-      relabel_configs:
-      - source_labels: [ __meta_kubernetes_service_label_context ]
-        action: keep
-        regex: garden
-      - source_labels: [ __meta_kubernetes_service_label_app ]
-        action: keep
-        regex: monitoring
-      - source_labels: [ __meta_kubernetes_service_label_role ]
-        action: keep
-        regex: alertmanager
-      - source_labels: [ __meta_kubernetes_endpoint_port_name ]
-        action: keep
-        regex: web
+    rule_files:
+    - /etc/prometheus/rules/*.yaml
 
-  scrape_configs: (( sum[list_files( __ctx.DIR "/manifests/scrape-configs" )|[]|scrape,sconf|-> scrape read( __ctx.DIR "/manifests/scrape-configs/" sconf )] ))
+    alerting:
+      alertmanagers:
+      - kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+            - garden
+        scheme: http
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_service_label_context ]
+          action: keep
+          regex: garden
+        - source_labels: [ __meta_kubernetes_service_label_app ]
+          action: keep
+          regex: monitoring
+        - source_labels: [ __meta_kubernetes_service_label_role ]
+          action: keep
+          regex: alertmanager
+        - source_labels: [ __meta_kubernetes_endpoint_port_name ]
+          action: keep
+          regex: web
+
+    scrape_configs: (( [templates.default_scrape_configs..., templates.custom_scrape_configs...] ))
+

--- a/components/monitoring/prometheus/manifests/02-prometheus-config.yaml
+++ b/components/monitoring/prometheus/manifests/02-prometheus-config.yaml
@@ -18,10 +18,19 @@ templates:
   default_scrape_configs: (( templates.parse_scrape_configs( __ctx.DIR "/manifests/scrape-configs" ) ))
   custom_scrape_configs: (( defined(templates.custom_path) ? templates.parse_scrape_configs( templates.custom_path ) :[] ))
 
+  remote_write:
+  - url: (( values.settings.monitoring.remoteWrite.url || ~~ ))
+    basic_auth:
+      username: (( values.settings.monitoring.remoteWrite.username || ~~ ))
+      password: (( values.settings.monitoring.remoteWrite.password || ~~ ))
+
   config_data:
     global:
       evaluation_interval: 30s
       scrape_interval: 30s
+      external_labels:
+        <<: (( values.settings.monitoring.externalLabels || ~~ ))
+    remote_write: (( defined(values.settings.monitoring.remoteWrite) ? templates.remote_write :~~ ))
 
     rule_files:
     - /etc/prometheus/rules/*.yaml

--- a/docs/extended/dashboard.md
+++ b/docs/extended/dashboard.md
@@ -2,8 +2,11 @@
 
 The `landscape.dashboard` node is entirely optional. 
 Whatever is specified for
+
 - `landscape.dashboard.frontendConfig`
 - `landscape.dashboard.gitHub`
+- `landscape.dashboard.resources`
+
 will be given directly to the [dashboard helm chart](https://github.com/gardener/dashboard/blob/master/charts/gardener-dashboard/values.yaml), so you can overwrite the corresponding default values.
 
 Please note that `frontendConfig.seedCandidateDeterminationStrategy` can not be overwritten here, as that value is derived from the Gardener. You can overwrite it [here](gardener.md).
@@ -54,4 +57,25 @@ The terminals need trusted certificates and won't work with self-signed ones. Th
 
 Due to technical limitations, some ingresses in shoot will have a `cert-manager.io/cluster-issuer: ...` annotation despite the cert-manager not being deployed on the shoots. To avoid conflicts when valid certificates are needed on a shoot, you can either use the [shoot-cert-service](https://github.com/gardener/gardener-extensions/tree/master/controllers/extension-shoot-cert-service), which is deployed on the shoot, or, if you want to use your own cert-manager deployment, make sure you choose a different name for your clusterissuer(s).
 
-Check out the [terminal-controller-manager](https://github.com/gardener/terminal-controller-manager) for more information on the terminals.
+Check out the
+[terminal-controller-manager](https://github.com/gardener/terminal-controller-manager)
+for more information on the terminals.
+
+### landscape.dashboard.resources
+
+With the optional `resources` field, you can override the default limits and requests for the dashboard.
+
+```yaml
+  ...
+  dashboard:
+    ...
+    resources:
+      requests:
+        cpu: 400m
+        memory: 2000Mi
+      limits:
+        cpu: 800m
+        memory: 2560Mi
+```
+
+This field expects the values in the standard Kubernetes format for resource requests and limits. Refer to the [Kubernetes docs for container resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for more information.

--- a/docs/extended/iaas.md
+++ b/docs/extended/iaas.md
@@ -42,6 +42,11 @@ iaas:
         enabled: true
       verticalPodAutoscaler:
         enabled: true
+    logging:                                     # optional, configure logging settings for the gardenlet
+    # fluentBit:                                 # example for FluentBit
+    #   output: |-
+    #     [Output]
+    #         ...
       ...
   - name:                                        # see above
     mode: <seed|cloudprofile|profile|inactive>   # what should be deployed

--- a/docs/extended/monitoring.md
+++ b/docs/extended/monitoring.md
@@ -7,11 +7,13 @@ landscape:
     active: false
     username: admin
     password: # password in clear-text
+    customScrapeConfigPath: ./my-scrape-configs
 ```
 
 Via the `landscape.monitoring` node, the monitoring feature can be activated. If activated, garden-setup will deploy a [Prometheus](https://prometheus.io/) and a [Grafana](https://grafana.com/) instance in the cluster, as well as the [Gardener Metrics Exporter](https://github.com/gardener/gardener-metrics-exporter). The monitoring is pre-configured and can not be adapted in the `acre.yaml` currently.
 - `monitoring.active`: if set to `true` (or anything else that is recognized as `true` by YAML), the monitoring components will be deployed. Defaults to `false`.
 - `monitoring.username`: the username for the ingress authentication to access the monitoring dashboards. Defaults to `admin`.
 - `monitoring.password`: the clear-text password for the ingress authentication to access the monitoring dashboards. Will be automatically generated and stored in the state (clear-text and hash) and export (hash only) of the `monitoring/prometheus` component, if not given.
+- `monitoring.customScrapeConfigPath`: if set, all `yaml` files in this folder will be added to the prometheus `scrape_config`. Preceding `./` can be omitted. Absolute aswell as relative paths like `../configs` work.
 
 Instead of username and password, `monitoring.hash` can be specified, containing a hash of the password. The hash should be created via `htpasswd -nb <username> <password>`.

--- a/docs/extended/monitoring.md
+++ b/docs/extended/monitoring.md
@@ -17,3 +17,27 @@ Via the `landscape.monitoring` node, the monitoring feature can be activated. If
 - `monitoring.customScrapeConfigPath`: if set, all `yaml` files in this folder will be added to the prometheus `scrape_config`. Preceding `./` can be omitted. Absolute aswell as relative paths like `../configs` work.
 
 Instead of username and password, `monitoring.hash` can be specified, containing a hash of the password. The hash should be created via `htpasswd -nb <username> <password>`.
+
+## Configure Prometheus `remote_write`
+
+You can also configure Prometheus to use the `remote_write` feature for central logging. See the 
+following configuration:
+
+```yaml
+landscape:
+  ...
+  monitoring:
+    ... # (see above)
+    remoteWrite:
+      url: # url path to remote_write endpoint
+      username: # remote_write username
+      password: # remote_write password
+    externalLabels:
+      key1: value1
+      key2: value2
+      ...
+```
+
+You can set credentials for the remote_write endpoint reachable at `url` using `username` and
+`password`. The optional user-defined key-value pairs underneath `externalLabels` are passed to
+the Prometheus _external labels_ config option.


### PR DESCRIPTION
**What this PR does / why we need it**:

@dergeberl introduced the remote_write feature to gardener in https://github.com/gardener/gardener/pull/4935 

This PR adds configuration options to enable this feature in garden-setup.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add remote_write prometheus configuration option
```
